### PR TITLE
Do not include ArduinoBearSSL if ArduinoIoTCloud is included

### DIFF
--- a/src/ArduinoCellular.cpp
+++ b/src/ArduinoCellular.cpp
@@ -35,8 +35,9 @@ void ArduinoCellular::begin() {
     modem.sendAT("+CNMI=2,1,0,0,0");
     modem.waitResponse();
 
-
+#if defined(ARDUINO_CELLULAR_BEARSSL)
     ArduinoBearSSL.onGetTime(ArduinoCellular::getTime);
+#endif
 
 }
 
@@ -155,6 +156,7 @@ HttpClient ArduinoCellular::getHTTPClient(const char * server, const int port){
     return HttpClient(* new TinyGsmClient(modem), server, port);
 }
 
+#if defined(ARDUINO_CELLULAR_BEARSSL)
 HttpClient ArduinoCellular::getHTTPSClient(const char * server, const int port){
     return HttpClient(* new BearSSLClient(* new TinyGsmClient(modem)), server, port);
 }
@@ -162,6 +164,7 @@ HttpClient ArduinoCellular::getHTTPSClient(const char * server, const int port){
 BearSSLClient ArduinoCellular::getSecureNetworkClient(){
     return BearSSLClient(* new TinyGsmClient(modem));
 }
+#endif
 
 bool ArduinoCellular::isConnectedToOperator(){
     return modem.isNetworkConnected();

--- a/src/ArduinoCellular.h
+++ b/src/ArduinoCellular.h
@@ -16,8 +16,18 @@
 
 #include <Arduino.h>
 #include <vector>
-#include "ArduinoBearSSLConfig.h"
-#include <ArduinoBearSSL.h>
+
+#if defined __has_include
+  #if !__has_include (<ArduinoIoTCloud.h>)
+    #define ARDUINO_CELLULAR_BEARSSL
+  #endif
+#endif
+
+#if defined(ARDUINO_CELLULAR_BEARSSL)
+  #include "ArduinoBearSSLConfig.h"
+  #include <ArduinoBearSSL.h>
+#endif
+
 #include <ModemInterface.h>
 #include <TimeUtils.h>
 
@@ -206,7 +216,9 @@ class ArduinoCellular {
          * @brief Gets the Transport Layer Security (TLS) client. (OSI Layer 4)
          * @return The GSM client.
          */
+#if defined(ARDUINO_CELLULAR_BEARSSL)
         BearSSLClient getSecureNetworkClient();
+#endif
 
         /**
          * @brief Gets the HTTP client for the specified server and port.


### PR DESCRIPTION
This will be a temporary fix until this PR https://github.com/arduino-libraries/ArduinoIoTCloud/pull/400 will be merged.

Is there any particular reason to keep this configuration ? 

https://github.com/arduino-libraries/Arduino_Cellular/blob/4e445aade71fc758ab8ec69103d36dc34c417bbc/src/ArduinoBearSSLConfig.h#L5

ArduinoIoTCloud needs ECCX08 for TLS handshake