### PR TITLE
Add NTPServerSync before getNetworkTime

### DIFF
--- a/src/ArduinoCellular.cpp
+++ b/src/ArduinoCellular.cpp
@@ -124,6 +124,7 @@ Time ArduinoCellular::getGPSTime(){
 Time ArduinoCellular::getCellularTime(){
     int year, month, day, hour, minute, second;
     float tz;
+    modem.NTPServerSync();
     modem.getNetworkTime(&year, &month, &day, &hour, &minute, &second, &tz);
     return Time(year, month, day, hour, minute, second);
 }

--- a/src/ArduinoCellular.cpp
+++ b/src/ArduinoCellular.cpp
@@ -122,10 +122,16 @@ Time ArduinoCellular::getGPSTime(){
 }
 
 Time ArduinoCellular::getCellularTime(){
-    int year, month, day, hour, minute, second;
+    int year = 1970;
+    int month = 1;
+    int day = 1;
+    int hour = 0;
+    int minute = 0;
+    int second = 0;
     float tz;
-    modem.NTPServerSync();
-    modem.getNetworkTime(&year, &month, &day, &hour, &minute, &second, &tz);
+    if (modem.NTPServerSync() == 0) {
+      modem.getNetworkTime(&year, &month, &day, &hour, &minute, &second, &tz);
+    }
     return Time(year, month, day, hour, minute, second);
 }
 


### PR DESCRIPTION
Calling `getNetworkTime` without `NTPServerSync` returns some weird time values in the past

`1388591169 -> Wed Jan 01 2014 15:46:09 GMT+0000`

Adding `NTPServerSync` call solves this issue