### PR TITLE
Avoid connect to APN to loop forever in case of missing connection

### DIFF
--- a/src/ArduinoCellular.cpp
+++ b/src/ArduinoCellular.cpp
@@ -44,7 +44,12 @@ void ArduinoCellular::begin() {
 
 }
 
-bool ArduinoCellular::connect(String apn, String username, String password){
+bool ArduinoCellular::connect(String apn, bool waitForever) {
+    connect(apn,String(""),String(""), waitForever);
+}
+
+
+bool ArduinoCellular::connect(String apn, String username, String password, bool waitForever){
     SimStatus simStatus = getSimStatus();
 
     if(simStatus == SimStatus::SIM_LOCKED){
@@ -62,7 +67,7 @@ bool ArduinoCellular::connect(String apn, String username, String password){
         return false;
     }
 
-    if(!awaitNetworkRegistration()){    
+    if(!awaitNetworkRegistration(waitForever)){
         return false;
     }
 
@@ -225,11 +230,16 @@ bool ArduinoCellular::unlockSIM(String pin){
     return modem.simUnlock(pin.c_str()); 
 }
 
-bool ArduinoCellular::awaitNetworkRegistration(){
+bool ArduinoCellular::awaitNetworkRegistration(bool waitForever){
     if(this->debugStream != nullptr){
         this->debugStream->println("Waiting for network registration...");
     }
     while (!modem.waitForNetwork(waitForNetworkTimeout)) {
+        
+        if(!waitForever) {
+            return false;
+        }
+
         if(this->debugStream != nullptr){
             this->debugStream->print(".");
         }

--- a/src/ArduinoCellular.h
+++ b/src/ArduinoCellular.h
@@ -127,7 +127,7 @@ class ArduinoCellular {
         /**
          * @brief same as previous, username and password are empty
          */
-        bool connect(String apn, bool waitForever);
+        bool connect(String apn, bool waitForever = true);
 
         /**
          * @brief Checks if the modem is registered on the network.

--- a/src/ArduinoCellular.h
+++ b/src/ArduinoCellular.h
@@ -259,14 +259,15 @@ class ArduinoCellular {
          */
         void setDebugStream(Stream& stream);
 
-    private:
-        bool connectToGPRS(const char * apn, const char * gprsUser, const char * gprsPass);
-        
-        /**
+		/**
          * @brief Gets the SIM card status.
          * @return The SIM card status.
          */
         SimStatus getSimStatus();
+
+    private:
+        bool connectToGPRS(const char * apn, const char * gprsUser, const char * gprsPass);
+        
 
         /**
          * @brief Waits for network registration. (Blocking call)

--- a/src/ArduinoCellular.h
+++ b/src/ArduinoCellular.h
@@ -119,9 +119,15 @@ class ArduinoCellular {
          * @param apn The Access Point Name.
          * @param username The APN username.
          * @param password The APN password.
+         * @param waitForever The function does not return unless a connection has been established
          * @return True if the connection is successful, false otherwise.
          */
-        bool connect(String apn = "", String username = "", String password = "");
+        bool connect(String apn = "", String username = "", String password = "", bool waitForever = true);
+        
+        /**
+         * @brief same as previous, username and password are empty
+         */
+        bool connect(String apn, bool waitForever);
 
         /**
          * @brief Checks if the modem is registered on the network.
@@ -271,9 +277,10 @@ class ArduinoCellular {
 
         /**
          * @brief Waits for network registration. (Blocking call)
+         * @param waitForever if true the function does not return until a connection has been established
          * @return True if the network registration is successful, false otherwise.
          */
-        bool awaitNetworkRegistration();
+        bool awaitNetworkRegistration(bool waitForever);
 
         /**
          * @brief Gets the GPS location. (Blocking call)


### PR DESCRIPTION
This PR introduces 2 changes (those changes have been found useful during Arduino Opta Cellular development, that uses this library):
1. the function `getSimStatus()` is now public (it is useful to have the chance to know if the SIM is available or it has to be unlocked)
2. The `connect` function in case the connection to the APN is not available (for example the antenna is missing and so a reliable communication cannot be established) was blocking. With this PR a parameter has been introduced to choose if the function must remain blocking (default) or it exits after a timeout.