### PR TITLE
Avoid to unlock the Sim if already unlocked

### DIFF
--- a/src/ArduinoCellular.cpp
+++ b/src/ArduinoCellular.cpp
@@ -205,13 +205,13 @@ SimStatus ArduinoCellular::getSimStatus(){
         this->debugStream->println("SIM Status: " + String(simStatus));
     }
 
-    if (modem.getSimStatus() == 0) {
+    if (simStatus == 0) {
         return SimStatus::SIM_ERROR;
-    } else if (modem.getSimStatus() == 1) {
+    } else if (simStatus == 1) {
         return SimStatus::SIM_READY;
-    } else if (modem.getSimStatus() == 2) {
+    } else if (simStatus == 2) {
         return SimStatus::SIM_LOCKED;
-    } else if (modem.getSimStatus() == 3) {
+    } else if (simStatus == 3) {
         return SimStatus::SIM_ANTITHEFT_LOCKED;
     } else {
         return SimStatus::SIM_ERROR;
@@ -219,10 +219,18 @@ SimStatus ArduinoCellular::getSimStatus(){
 }
 
 bool ArduinoCellular::unlockSIM(String pin){
-    if(this->debugStream != nullptr){
-        this->debugStream->println("Unlocking SIM...");
+    int simStatus = modem.getSimStatus();
+    if(simStatus == SIM_LOCKED) {
+        if(this->debugStream != nullptr){
+            this->debugStream->println("Unlocking SIM...");
+        }
+        return modem.simUnlock(pin.c_str());
     }
-    return modem.simUnlock(pin.c_str()); 
+    else if(simStatus == SIM_ERROR || simStatus == SIM_ANTITHEFT_LOCKED) {
+        return false;
+    }
+    /* SIM is ready */
+    return true;
 }
 
 bool ArduinoCellular::awaitNetworkRegistration(){


### PR DESCRIPTION
This PR avoid to try to unlock the SIM if the SIM is already unlocked.
If the SIM is unlocked and there is an attempt to unlock it (this happens in Arduino_ConnectionHandler in `update_handleInit()` function) the modem return an error (at least in Opta Cellular device) and this prevent the connection to the network.
So it seems sensible to avoid to unlock the SIM if the SIM is READY.
Also this PR introduces a change in the function  `getSimStatus()` in order to avoid to call multiple time `modem.getSimStatus()` that involves useless communication with modem. 