### PR TITLE
Fix getTime() timezone

### DIFF
--- a/src/ArduinoCellular.cpp
+++ b/src/ArduinoCellular.cpp
@@ -8,7 +8,7 @@
 unsigned long ArduinoCellular::getTime() {
     int year, month, day, hour, minute, second;
     float tz;
-    modem.getNetworkTime(&year, &month, &day, &hour, &minute, &second, &tz);
+    modem.getNetworkUTCTime(&year, &month, &day, &hour, &minute, &second, &tz);
     return Time(year, month, day, hour, minute, second).getUNIXTimestamp();
 }
 

--- a/src/ArduinoCellular.cpp
+++ b/src/ArduinoCellular.cpp
@@ -6,9 +6,16 @@
 #endif
 
 unsigned long ArduinoCellular::getTime() {
-    int year, month, day, hour, minute, second;
+    int year = 1970;
+    int month = 1;
+    int day = 1;
+    int hour = 0;
+    int minute = 0;
+    int second = 0;
     float tz;
-    modem.getNetworkUTCTime(&year, &month, &day, &hour, &minute, &second, &tz);
+    if (modem.NTPServerSync() == 0) {
+      modem.getNetworkUTCTime(&year, &month, &day, &hour, &minute, &second, &tz);
+    }
     return Time(year, month, day, hour, minute, second).getUNIXTimestamp();
 }
 


### PR DESCRIPTION
with this changes we ansure getTime is always using UTC timezone and we can check NTP is synced comparing output with UNIX epoch.